### PR TITLE
Add verification for tty_tickets in /etc/sudoers

### DIFF
--- a/commands.yaml
+++ b/commands.yaml
@@ -269,6 +269,13 @@
   enabled: true
 
 
+- title: "Verify that sudo is configured with the tty_tickets flag"
+  check_command: |
+    sudo cat /etc/sudoers | egrep '^Defaults.*\s+tty_tickets'
+  comment: "Enforce the tty_tickets flag to limit the sudo session timeout to the same TTY session. For a justification, see: https://www.stigviewer.com/stig/apple_os_x_10.9_mavericks_workstation/2015-02-26/finding/V-58415"
+  enabled: true
+
+
 - title: "Verify no HTTP update URLs for Sparkle Updater"
   check_command: |
     for i in /Applications/*/Contents/Info.plist; do URL=$(defaults read "$i" SUFeedURL 2>/dev/null | grep "http://"); if [ -n "$URL" ]; then exit 1; fi; done; exit 0


### PR DESCRIPTION
`sudo` is by default configured without the `tty_tickets` flag. Using `sudo` once will start a (5-minute) session within which no password is required for subsequent uses. However, this `sudo` session is not bound to the TTY session (i.e. a Terminal window/tab, a shell session with `su` or `login` or even a shell pipe using another language, run in another program) within which the command was first called. This means that any other (TTY) session that runs under the user during this `sudo` session can call `sudo` without entering a password.

Addressing this requires editing `/etc/sudoers` using the `visudo` command. Then the following line must be added:

```
Defaults    tty_tickets
```

References:
- https://www.stigviewer.com/stig/apple_os_x_10.9_mavericks_workstation/2015-02-26/finding/V-58415
- http://csrc.nist.gov/publications/drafts/800-179/sp800_179_draft.pdf (p. 101)
- https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man5/sudoers.5.html (Search for ‘tty_tickets’. The documentation is actually wrong about the default.)
- http://bugs.debian.org/567614 (Similar issue on Debian, now fixed.)
